### PR TITLE
Round Filtering

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,3 +16,8 @@ jobs:
           echo "Running backend tests"
           cd backend
           go test -v ./tests/...
+      
+      # Cleanup
+      - run: |
+          echo "Docker Cleanup"
+          docker system prune -f

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -37,6 +37,125 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/api/v1/fixtures": {
+            "get": {
+                "description": "Get all fixtures",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "fixtures"
+                ],
+                "summary": "Retrieve a list of all fixtures",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "example": 1,
+                        "description": "Round number",
+                        "name": "round",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.APIFixture"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/fixtures/{competition_id}": {
+            "get": {
+                "description": "Get fixtures by competition ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "fixtures"
+                ],
+                "summary": "Retrieve fixtures for a specific competition",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "example": 111,
+                        "description": "Competition ID",
+                        "name": "competition_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "example": 1,
+                        "description": "Round number",
+                        "name": "round",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.APIFixture"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid competition_id"
+                    }
+                }
+            }
+        },
+        "/api/v1/fixtures/{competition_id}/{match_id}": {
+            "get": {
+                "description": "Get detailed information for a specific match within a competition.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "fixtures"
+                ],
+                "summary": "Retrieve match details",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "example": 111,
+                        "description": "Competition ID",
+                        "name": "competition_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "example": 20241610510,
+                        "description": "Match ID",
+                        "name": "match_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.APIFixture"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid competition_id or match_id, or Fixture does not belong to the specified competition"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -45,11 +164,94 @@ const docTemplate = `{
             "properties": {
                 "id": {
                     "description": "Unique identifier for the competition",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 111
                 },
                 "name": {
-                    "description": "Name of the competition (e.g., \"NRL\", \"NRLW\")",
-                    "type": "string"
+                    "description": "Name of the competition",
+                    "type": "string",
+                    "example": "NRL"
+                }
+            }
+        },
+        "models.APIFixture": {
+            "type": "object",
+            "properties": {
+                "away_team": {
+                    "description": "Away team details",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.APITeam"
+                        }
+                    ]
+                },
+                "competition_id": {
+                    "description": "The competition ID this fixture belongs to",
+                    "type": "integer",
+                    "example": 111
+                },
+                "home_team": {
+                    "description": "Home team details",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.APITeam"
+                        }
+                    ]
+                },
+                "id": {
+                    "description": "Unique identifier for the fixture",
+                    "type": "integer",
+                    "example": 20241610510
+                },
+                "kick_off_time": {
+                    "description": "Kickoff time of the match in RFC3339 format",
+                    "type": "string",
+                    "example": "2024-08-24T01:00:00Z"
+                },
+                "match_state": {
+                    "description": "Current state of the match",
+                    "type": "string",
+                    "example": "FullTime"
+                },
+                "round_title": {
+                    "description": "The title of the round",
+                    "type": "string",
+                    "example": "Round 22"
+                },
+                "venue": {
+                    "description": "Venue of the match",
+                    "type": "string",
+                    "example": "Leichhardt Oval"
+                },
+                "venue_city": {
+                    "description": "City where the venue is located",
+                    "type": "string",
+                    "example": "Sydney"
+                }
+            }
+        },
+        "models.APITeam": {
+            "type": "object",
+            "properties": {
+                "form": {
+                    "description": "Recent form of the team",
+                    "type": "string",
+                    "example": "WLWWL"
+                },
+                "nickname": {
+                    "description": "Nickname of the team",
+                    "type": "string",
+                    "example": "Cowboys"
+                },
+                "odds": {
+                    "description": "Odds for the team to win",
+                    "type": "number",
+                    "example": 3.42
+                },
+                "score": {
+                    "description": "Final score of the team",
+                    "type": "integer",
+                    "example": 40
                 }
             }
         }

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -48,15 +48,6 @@ const docTemplate = `{
                     "fixtures"
                 ],
                 "summary": "Retrieve a list of all fixtures",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "example": 1,
-                        "description": "Round number",
-                        "name": "round",
-                        "in": "query"
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -29,6 +29,125 @@
                     }
                 }
             }
+        },
+        "/api/v1/fixtures": {
+            "get": {
+                "description": "Get all fixtures",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "fixtures"
+                ],
+                "summary": "Retrieve a list of all fixtures",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "example": 1,
+                        "description": "Round number",
+                        "name": "round",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.APIFixture"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/fixtures/{competition_id}": {
+            "get": {
+                "description": "Get fixtures by competition ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "fixtures"
+                ],
+                "summary": "Retrieve fixtures for a specific competition",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "example": 111,
+                        "description": "Competition ID",
+                        "name": "competition_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "example": 1,
+                        "description": "Round number",
+                        "name": "round",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.APIFixture"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid competition_id"
+                    }
+                }
+            }
+        },
+        "/api/v1/fixtures/{competition_id}/{match_id}": {
+            "get": {
+                "description": "Get detailed information for a specific match within a competition.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "fixtures"
+                ],
+                "summary": "Retrieve match details",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "example": 111,
+                        "description": "Competition ID",
+                        "name": "competition_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "example": 20241610510,
+                        "description": "Match ID",
+                        "name": "match_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.APIFixture"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid competition_id or match_id, or Fixture does not belong to the specified competition"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -37,11 +156,94 @@
             "properties": {
                 "id": {
                     "description": "Unique identifier for the competition",
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 111
                 },
                 "name": {
-                    "description": "Name of the competition (e.g., \"NRL\", \"NRLW\")",
-                    "type": "string"
+                    "description": "Name of the competition",
+                    "type": "string",
+                    "example": "NRL"
+                }
+            }
+        },
+        "models.APIFixture": {
+            "type": "object",
+            "properties": {
+                "away_team": {
+                    "description": "Away team details",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.APITeam"
+                        }
+                    ]
+                },
+                "competition_id": {
+                    "description": "The competition ID this fixture belongs to",
+                    "type": "integer",
+                    "example": 111
+                },
+                "home_team": {
+                    "description": "Home team details",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.APITeam"
+                        }
+                    ]
+                },
+                "id": {
+                    "description": "Unique identifier for the fixture",
+                    "type": "integer",
+                    "example": 20241610510
+                },
+                "kick_off_time": {
+                    "description": "Kickoff time of the match in RFC3339 format",
+                    "type": "string",
+                    "example": "2024-08-24T01:00:00Z"
+                },
+                "match_state": {
+                    "description": "Current state of the match",
+                    "type": "string",
+                    "example": "FullTime"
+                },
+                "round_title": {
+                    "description": "The title of the round",
+                    "type": "string",
+                    "example": "Round 22"
+                },
+                "venue": {
+                    "description": "Venue of the match",
+                    "type": "string",
+                    "example": "Leichhardt Oval"
+                },
+                "venue_city": {
+                    "description": "City where the venue is located",
+                    "type": "string",
+                    "example": "Sydney"
+                }
+            }
+        },
+        "models.APITeam": {
+            "type": "object",
+            "properties": {
+                "form": {
+                    "description": "Recent form of the team",
+                    "type": "string",
+                    "example": "WLWWL"
+                },
+                "nickname": {
+                    "description": "Nickname of the team",
+                    "type": "string",
+                    "example": "Cowboys"
+                },
+                "odds": {
+                    "description": "Odds for the team to win",
+                    "type": "number",
+                    "example": 3.42
+                },
+                "score": {
+                    "description": "Final score of the team",
+                    "type": "integer",
+                    "example": 40
                 }
             }
         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -40,15 +40,6 @@
                     "fixtures"
                 ],
                 "summary": "Retrieve a list of all fixtures",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "example": 1,
-                        "description": "Round number",
-                        "name": "round",
-                        "in": "query"
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -92,12 +92,6 @@ paths:
   /api/v1/fixtures:
     get:
       description: Get all fixtures
-      parameters:
-      - description: Round number
-        example: 1
-        in: query
-        name: round
-        type: integer
       produces:
       - application/json
       responses:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -3,10 +3,70 @@ definitions:
     properties:
       id:
         description: Unique identifier for the competition
+        example: 111
         type: integer
       name:
-        description: Name of the competition (e.g., "NRL", "NRLW")
+        description: Name of the competition
+        example: NRL
         type: string
+    type: object
+  models.APIFixture:
+    properties:
+      away_team:
+        allOf:
+        - $ref: '#/definitions/models.APITeam'
+        description: Away team details
+      competition_id:
+        description: The competition ID this fixture belongs to
+        example: 111
+        type: integer
+      home_team:
+        allOf:
+        - $ref: '#/definitions/models.APITeam'
+        description: Home team details
+      id:
+        description: Unique identifier for the fixture
+        example: 20241610510
+        type: integer
+      kick_off_time:
+        description: Kickoff time of the match in RFC3339 format
+        example: "2024-08-24T01:00:00Z"
+        type: string
+      match_state:
+        description: Current state of the match
+        example: FullTime
+        type: string
+      round_title:
+        description: The title of the round
+        example: Round 22
+        type: string
+      venue:
+        description: Venue of the match
+        example: Leichhardt Oval
+        type: string
+      venue_city:
+        description: City where the venue is located
+        example: Sydney
+        type: string
+    type: object
+  models.APITeam:
+    properties:
+      form:
+        description: Recent form of the team
+        example: WLWWL
+        type: string
+      nickname:
+        description: Nickname of the team
+        example: Cowboys
+        type: string
+      odds:
+        description: Odds for the team to win
+        example: 3.42
+        type: number
+      score:
+        description: Final score of the team
+        example: 40
+        type: integer
     type: object
 info:
   contact: {}
@@ -29,4 +89,85 @@ paths:
       summary: Retrieve a list of all available competitions
       tags:
       - competitions
+  /api/v1/fixtures:
+    get:
+      description: Get all fixtures
+      parameters:
+      - description: Round number
+        example: 1
+        in: query
+        name: round
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.APIFixture'
+            type: array
+      summary: Retrieve a list of all fixtures
+      tags:
+      - fixtures
+  /api/v1/fixtures/{competition_id}:
+    get:
+      description: Get fixtures by competition ID
+      parameters:
+      - description: Competition ID
+        example: 111
+        in: path
+        name: competition_id
+        required: true
+        type: integer
+      - description: Round number
+        example: 1
+        in: query
+        name: round
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.APIFixture'
+            type: array
+        "400":
+          description: Invalid competition_id
+      summary: Retrieve fixtures for a specific competition
+      tags:
+      - fixtures
+  /api/v1/fixtures/{competition_id}/{match_id}:
+    get:
+      description: Get detailed information for a specific match within a competition.
+      parameters:
+      - description: Competition ID
+        example: 111
+        in: path
+        name: competition_id
+        required: true
+        type: integer
+      - description: Match ID
+        example: 20241610510
+        in: path
+        name: match_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.APIFixture'
+        "400":
+          description: Invalid competition_id or match_id, or Fixture does not belong
+            to the specified competition
+        "500":
+          description: Internal server error
+      summary: Retrieve match details
+      tags:
+      - fixtures
 swagger: "2.0"

--- a/backend/internal/db/match_details.sql.go
+++ b/backend/internal/db/match_details.sql.go
@@ -253,6 +253,149 @@ func (q *Queries) ListMatchDetailsByCompetitionID(ctx context.Context, competiti
 	return items, nil
 }
 
+const listRoundMatchDetails = `-- name: ListRoundMatchDetails :many
+SELECT 
+  md.fixture_id, md.hometeam_id, md.awayteam_id, md.hometeam_odds, md.awayteam_odds, md.hometeam_score, md.awayteam_score, md.hometeam_form, md.awayteam_form, md.winner_teamid, 
+  f.id, f.competition_id, f.roundtitle, f.matchstate, f.venue, f.venuecity, f.matchcentreurl, f.kickofftime, 
+  home_team.id, home_team.nickname, home_team.competition_id, 
+  away_team.id, away_team.nickname, away_team.competition_id
+FROM match_details md
+JOIN fixtures f ON md.fixture_id = f.id
+JOIN teams home_team ON md.homeTeam_id = home_team.id
+JOIN teams away_team ON md.awayTeam_id = away_team.id
+WHERE f.roundTitle = $1
+ORDER BY f.kickOffTime
+`
+
+type ListRoundMatchDetailsRow struct {
+	MatchDetail MatchDetail
+	Fixture     Fixture
+	Team        Team
+	Team_2      Team
+}
+
+// Retrieve all match details available in the system by round number.
+func (q *Queries) ListRoundMatchDetails(ctx context.Context, roundtitle string) ([]*ListRoundMatchDetailsRow, error) {
+	rows, err := q.db.Query(ctx, listRoundMatchDetails, roundtitle)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListRoundMatchDetailsRow
+	for rows.Next() {
+		var i ListRoundMatchDetailsRow
+		if err := rows.Scan(
+			&i.MatchDetail.FixtureID,
+			&i.MatchDetail.HometeamID,
+			&i.MatchDetail.AwayteamID,
+			&i.MatchDetail.HometeamOdds,
+			&i.MatchDetail.AwayteamOdds,
+			&i.MatchDetail.HometeamScore,
+			&i.MatchDetail.AwayteamScore,
+			&i.MatchDetail.HometeamForm,
+			&i.MatchDetail.AwayteamForm,
+			&i.MatchDetail.WinnerTeamid,
+			&i.Fixture.ID,
+			&i.Fixture.CompetitionID,
+			&i.Fixture.Roundtitle,
+			&i.Fixture.Matchstate,
+			&i.Fixture.Venue,
+			&i.Fixture.Venuecity,
+			&i.Fixture.Matchcentreurl,
+			&i.Fixture.Kickofftime,
+			&i.Team.ID,
+			&i.Team.Nickname,
+			&i.Team.CompetitionID,
+			&i.Team_2.ID,
+			&i.Team_2.Nickname,
+			&i.Team_2.CompetitionID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRoundMatchDetailsByCompetitionID = `-- name: ListRoundMatchDetailsByCompetitionID :many
+SELECT 
+  md.fixture_id, md.hometeam_id, md.awayteam_id, md.hometeam_odds, md.awayteam_odds, md.hometeam_score, md.awayteam_score, md.hometeam_form, md.awayteam_form, md.winner_teamid, 
+  f.id, f.competition_id, f.roundtitle, f.matchstate, f.venue, f.venuecity, f.matchcentreurl, f.kickofftime, 
+  home_team.id, home_team.nickname, home_team.competition_id, 
+  away_team.id, away_team.nickname, away_team.competition_id
+FROM match_details md
+JOIN fixtures f ON md.fixture_id = f.id
+JOIN teams home_team ON md.homeTeam_id = home_team.id
+JOIN teams away_team ON md.awayTeam_id = away_team.id
+WHERE 
+  f.competition_id = $1
+  AND f.roundTitle = $2
+ORDER BY f.kickOffTime
+`
+
+type ListRoundMatchDetailsByCompetitionIDParams struct {
+	CompetitionID int64
+	Roundtitle    string
+}
+
+type ListRoundMatchDetailsByCompetitionIDRow struct {
+	MatchDetail MatchDetail
+	Fixture     Fixture
+	Team        Team
+	Team_2      Team
+}
+
+// Retrieve all match details for a specific competition ID.
+// This query performs a JOIN between match_details and fixtures to get all
+// match details that are part of a specific competition and round.
+func (q *Queries) ListRoundMatchDetailsByCompetitionID(ctx context.Context, arg ListRoundMatchDetailsByCompetitionIDParams) ([]*ListRoundMatchDetailsByCompetitionIDRow, error) {
+	rows, err := q.db.Query(ctx, listRoundMatchDetailsByCompetitionID, arg.CompetitionID, arg.Roundtitle)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListRoundMatchDetailsByCompetitionIDRow
+	for rows.Next() {
+		var i ListRoundMatchDetailsByCompetitionIDRow
+		if err := rows.Scan(
+			&i.MatchDetail.FixtureID,
+			&i.MatchDetail.HometeamID,
+			&i.MatchDetail.AwayteamID,
+			&i.MatchDetail.HometeamOdds,
+			&i.MatchDetail.AwayteamOdds,
+			&i.MatchDetail.HometeamScore,
+			&i.MatchDetail.AwayteamScore,
+			&i.MatchDetail.HometeamForm,
+			&i.MatchDetail.AwayteamForm,
+			&i.MatchDetail.WinnerTeamid,
+			&i.Fixture.ID,
+			&i.Fixture.CompetitionID,
+			&i.Fixture.Roundtitle,
+			&i.Fixture.Matchstate,
+			&i.Fixture.Venue,
+			&i.Fixture.Venuecity,
+			&i.Fixture.Matchcentreurl,
+			&i.Fixture.Kickofftime,
+			&i.Team.ID,
+			&i.Team.Nickname,
+			&i.Team.CompetitionID,
+			&i.Team_2.ID,
+			&i.Team_2.Nickname,
+			&i.Team_2.CompetitionID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateMatchDetail = `-- name: UpdateMatchDetail :one
 UPDATE match_details 
 SET 

--- a/backend/internal/db/migration/000005_competition_round_state.down.sql
+++ b/backend/internal/db/migration/000005_competition_round_state.down.sql
@@ -1,0 +1,3 @@
+-- Down migration to remove the 'round' column from the competitions table
+ALTER TABLE competitions
+DROP COLUMN round;

--- a/backend/internal/db/migration/000005_competition_round_state.up.sql
+++ b/backend/internal/db/migration/000005_competition_round_state.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE competitions
+ADD COLUMN round VARCHAR(50);
+
+COMMENT ON COLUMN competitions.round IS 'Indicates the current round or game for the competition (e.g., Round 1 for NRL, Game 1 for State of Origin)';

--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -13,6 +13,8 @@ type Competition struct {
 	ID int64
 	// Name of the competition (e.g., NRL, NRLW)
 	Name string
+	// Indicates the current round or game for the competition (e.g., Round 1 for NRL, Game 1 for State of Origin)
+	Round *string
 }
 
 type Fixture struct {

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -47,6 +47,12 @@ type Querier interface {
 	// This query performs a JOIN between match_details and fixtures to get all
 	// match details that are part of a specific competition.
 	ListMatchDetailsByCompetitionID(ctx context.Context, competitionID int64) ([]*ListMatchDetailsByCompetitionIDRow, error)
+	// Retrieve all match details available in the system by round number.
+	ListRoundMatchDetails(ctx context.Context, roundtitle string) ([]*ListRoundMatchDetailsRow, error)
+	// Retrieve all match details for a specific competition ID.
+	// This query performs a JOIN between match_details and fixtures to get all
+	// match details that are part of a specific competition and round.
+	ListRoundMatchDetailsByCompetitionID(ctx context.Context, arg ListRoundMatchDetailsByCompetitionIDParams) ([]*ListRoundMatchDetailsByCompetitionIDRow, error)
 	// Retrieve all teams available in the system.
 	ListTeams(ctx context.Context) ([]*Team, error)
 	// Conditionally update fixture details based on provided arguments.

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -38,6 +38,10 @@ type Querier interface {
 	// reference this table to establish a relationship.
 	// Retrieve all competitions available in the system.
 	ListCompetitions(ctx context.Context) ([]*Competition, error)
+	// Retrieve all match details for a specific competition ID.
+	// This query performs a JOIN between match_details and fixtures to get all
+	// match details that are part of a specific competition and round.
+	ListCurrentRoundMatchDetailsByCompetitionID(ctx context.Context, id int64) ([]*ListCurrentRoundMatchDetailsByCompetitionIDRow, error)
 	// Retrieve all fixtures available in the system.
 	// This query is used to list all fixtures without filtering by any criteria.
 	ListFixtures(ctx context.Context) ([]*Fixture, error)
@@ -47,8 +51,6 @@ type Querier interface {
 	// This query performs a JOIN between match_details and fixtures to get all
 	// match details that are part of a specific competition.
 	ListMatchDetailsByCompetitionID(ctx context.Context, competitionID int64) ([]*ListMatchDetailsByCompetitionIDRow, error)
-	// Retrieve all match details available in the system by round number.
-	ListRoundMatchDetails(ctx context.Context, roundtitle string) ([]*ListRoundMatchDetailsRow, error)
 	// Retrieve all match details for a specific competition ID.
 	// This query performs a JOIN between match_details and fixtures to get all
 	// match details that are part of a specific competition and round.

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -55,6 +55,19 @@ type Querier interface {
 	ListRoundMatchDetailsByCompetitionID(ctx context.Context, arg ListRoundMatchDetailsByCompetitionIDParams) ([]*ListRoundMatchDetailsByCompetitionIDRow, error)
 	// Retrieve all teams available in the system.
 	ListTeams(ctx context.Context) ([]*Team, error)
+	// The following commands for creating, updating, and deleting competitions
+	// are not required since this is a static table with fixed records:
+	// - NRL (111)
+	// - NRLW (161)
+	// - State of Origin (116)
+	// - State of Origin Womens (156)
+	//
+	// However, if future updates to this table are needed (e.g., new competitions),
+	// you may add additional commands to handle such changes.
+	// Update the current round for a competition.
+	// This query updates the round field for a specific competition based on the
+	// provided competition ID.
+	UpdateCompetitionRound(ctx context.Context, arg UpdateCompetitionRoundParams) (*Competition, error)
 	// Conditionally update fixture details based on provided arguments.
 	// This query updates the fields of a fixture record where the provided arguments
 	// are not NULL. It uses the COALESCE function to retain the existing value if

--- a/backend/internal/db/query/competitions.sql
+++ b/backend/internal/db/query/competitions.sql
@@ -19,3 +19,13 @@ SELECT * FROM competitions WHERE id = $1;
 --
 -- However, if future updates to this table are needed (e.g., new competitions),
 -- you may add additional commands to handle such changes.
+
+
+-- name: UpdateCompetitionRound :one
+-- Update the current round for a competition.
+-- This query updates the round field for a specific competition based on the
+-- provided competition ID.
+UPDATE competitions
+SET round = $2
+WHERE id = $1
+RETURNING *;

--- a/backend/internal/db/query/match_details.sql
+++ b/backend/internal/db/query/match_details.sql
@@ -25,6 +25,20 @@ JOIN teams home_team ON md.homeTeam_id = home_team.id
 JOIN teams away_team ON md.awayTeam_id = away_team.id
 ORDER BY f.kickOffTime;
 
+-- name: ListRoundMatchDetails :many
+-- Retrieve all match details available in the system by round number.
+SELECT 
+  sqlc.embed(md), 
+  sqlc.embed(f), 
+  sqlc.embed(home_team), 
+  sqlc.embed(away_team)
+FROM match_details md
+JOIN fixtures f ON md.fixture_id = f.id
+JOIN teams home_team ON md.homeTeam_id = home_team.id
+JOIN teams away_team ON md.awayTeam_id = away_team.id
+WHERE f.roundTitle = $1
+ORDER BY f.kickOffTime;
+
 -- name: ListMatchDetailsByCompetitionID :many
 -- Retrieve all match details for a specific competition ID.
 -- This query performs a JOIN between match_details and fixtures to get all 
@@ -39,6 +53,24 @@ JOIN fixtures f ON md.fixture_id = f.id
 JOIN teams home_team ON md.homeTeam_id = home_team.id
 JOIN teams away_team ON md.awayTeam_id = away_team.id
 WHERE f.competition_id = $1
+ORDER BY f.kickOffTime;
+
+-- name: ListRoundMatchDetailsByCompetitionID :many
+-- Retrieve all match details for a specific competition ID.
+-- This query performs a JOIN between match_details and fixtures to get all 
+-- match details that are part of a specific competition and round.
+SELECT 
+  sqlc.embed(md), 
+  sqlc.embed(f), 
+  sqlc.embed(home_team), 
+  sqlc.embed(away_team)
+FROM match_details md
+JOIN fixtures f ON md.fixture_id = f.id
+JOIN teams home_team ON md.homeTeam_id = home_team.id
+JOIN teams away_team ON md.awayTeam_id = away_team.id
+WHERE 
+  f.competition_id = $1
+  AND f.roundTitle = $2
 ORDER BY f.kickOffTime;
 
 -- name: CreateMatchDetail :one

--- a/backend/internal/db/query/match_details.sql
+++ b/backend/internal/db/query/match_details.sql
@@ -25,20 +25,6 @@ JOIN teams home_team ON md.homeTeam_id = home_team.id
 JOIN teams away_team ON md.awayTeam_id = away_team.id
 ORDER BY f.kickOffTime;
 
--- name: ListRoundMatchDetails :many
--- Retrieve all match details available in the system by round number.
-SELECT 
-  sqlc.embed(md), 
-  sqlc.embed(f), 
-  sqlc.embed(home_team), 
-  sqlc.embed(away_team)
-FROM match_details md
-JOIN fixtures f ON md.fixture_id = f.id
-JOIN teams home_team ON md.homeTeam_id = home_team.id
-JOIN teams away_team ON md.awayTeam_id = away_team.id
-WHERE f.roundTitle = $1
-ORDER BY f.kickOffTime;
-
 -- name: ListMatchDetailsByCompetitionID :many
 -- Retrieve all match details for a specific competition ID.
 -- This query performs a JOIN between match_details and fixtures to get all 
@@ -71,6 +57,25 @@ JOIN teams away_team ON md.awayTeam_id = away_team.id
 WHERE 
   f.competition_id = $1
   AND f.roundTitle = $2
+ORDER BY f.kickOffTime;
+
+-- name: ListCurrentRoundMatchDetailsByCompetitionID :many
+-- Retrieve all match details for a specific competition ID.
+-- This query performs a JOIN between match_details and fixtures to get all 
+-- match details that are part of a specific competition and round.
+SELECT 
+  sqlc.embed(md), 
+  sqlc.embed(f), 
+  sqlc.embed(home_team), 
+  sqlc.embed(away_team)
+FROM match_details md
+JOIN fixtures f ON md.fixture_id = f.id
+JOIN teams home_team ON md.homeTeam_id = home_team.id
+JOIN teams away_team ON md.awayTeam_id = away_team.id
+JOIN competitions c ON f.competition_id = c.id
+WHERE 
+  c.id = $1
+  AND f.roundTitle = c.round
 ORDER BY f.kickOffTime;
 
 -- name: CreateMatchDetail :one

--- a/backend/internal/db/query/teams.sql
+++ b/backend/internal/db/query/teams.sql
@@ -8,7 +8,7 @@ SELECT * FROM teams WHERE id = $1;
 
 -- name: CreateTeam :one
 -- Insert a new team into the teams table.
--- If a team with the same team_id already exists, do nothing.
+-- If a team with the same id already exists, do nothing.
 INSERT INTO teams (id, nickName, competition_id) 
 VALUES ($1, $2, $3)
 RETURNING *;

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -106,7 +106,13 @@ func (h *Handlers) GetCompetitionFixtures(w http.ResponseWriter, r *http.Request
 	var fixtures []models.APIFixture
 
 	round := r.URL.Query().Get("round")
-	if round != "" {
+	if round == "all" {
+		fixtures, err = h.dataService.GetCompetitionFixtures(int64(competitionID))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	} else if round != "" {
 		// Convert the round to an integer
 		roundNum, err := strconv.Atoi(round)
 		if err != nil {
@@ -120,7 +126,7 @@ func (h *Handlers) GetCompetitionFixtures(w http.ResponseWriter, r *http.Request
 			return
 		}
 	} else {
-		fixtures, err = h.dataService.GetCompetitionFixtures(int64(competitionID))
+		fixtures, err = h.dataService.GetCompetitionCurrentFixtures(int64(competitionID))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -59,33 +59,13 @@ func (h *Handlers) GetCompetitions(w http.ResponseWriter, r *http.Request) {
 // @Description Get all fixtures
 // @Tags fixtures
 // @Produce json
-// @Param round query int false "Round number" example(1)
 // @Success 200 {array} models.APIFixture
 // @Router /api/v1/fixtures [get]
 func (h *Handlers) GetFixtures(w http.ResponseWriter, r *http.Request) {
-	var fixtures []models.APIFixture
-	var err error
-
-	round := r.URL.Query().Get("round")
-	if round != "" {
-		// Convert the round to an integer
-		roundNum, err := strconv.Atoi(round)
-		if err != nil {
-			http.Error(w, "Invalid round query parameter", http.StatusBadRequest)
-			return
-		}
-
-		fixtures, err = h.dataService.GetRoundFixtures(roundNum)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	} else {
-		fixtures, err = h.dataService.GetFixtures()
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+	fixtures, err := h.dataService.GetFixtures()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -134,7 +114,7 @@ func (h *Handlers) GetCompetitionFixtures(w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		fixtures, err = h.dataService.GetRoundFixtures(roundNum)
+		fixtures, err = h.dataService.GetRoundCompetitionFixtures(int64(competitionID), roundNum)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/backend/internal/models/nrl.go
+++ b/backend/internal/models/nrl.go
@@ -2,6 +2,7 @@ package models
 
 type NRLFixture struct {
 	ID             string  `json:"matchId"`
+	IsCurrentRound bool    `json:"isCurrentRound"`
 	RoundTitle     string  `json:"roundTitle"`
 	MatchState     string  `json:"matchState"`
 	Venue          string  `json:"venue"`

--- a/backend/internal/services/api_data_service.go
+++ b/backend/internal/services/api_data_service.go
@@ -115,6 +115,42 @@ func (s *APIDataService) GetCompetitionFixtures(competitionId int64) ([]models.A
 	return apiFixtures, nil
 }
 
+// GetCompetitionFixtures fetches fixtures for a specific competition for the current/latest round and converts them to API models.
+func (s *APIDataService) GetCompetitionCurrentFixtures(competitionId int64) ([]models.APIFixture, error) {
+	fixtures, err := s.queries.ListCurrentRoundMatchDetailsByCompetitionID(s.ctx, competitionId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert database models to API models.
+	apiFixtures := make([]models.APIFixture, 0)
+	for _, f := range fixtures {
+		apiFixtures = append(apiFixtures, models.APIFixture{
+			ID:            f.Fixture.ID,
+			CompetitionID: f.Fixture.CompetitionID,
+			RoundTitle:    f.Fixture.Roundtitle,
+			MatchState:    f.Fixture.Matchstate,
+			Venue:         f.Fixture.Venue,
+			VenueCity:     f.Fixture.Venuecity,
+			HomeTeam: models.APITeam{
+				Nickname: f.Team.Nickname,
+				Score:    f.MatchDetail.HometeamScore,
+				Odds:     f.MatchDetail.HometeamOdds,
+				Form:     f.MatchDetail.HometeamForm,
+			},
+			AwayTeam: models.APITeam{
+				Nickname: f.Team_2.Nickname,
+				Score:    f.MatchDetail.AwayteamScore,
+				Odds:     f.MatchDetail.AwayteamOdds,
+				Form:     f.MatchDetail.AwayteamForm,
+			},
+			KickOffTime: f.Fixture.Kickofftime.Time,
+		})
+	}
+
+	return apiFixtures, nil
+}
+
 // GetCompetitionFixtures fetches fixtures for a specific competition and converts them to API models.
 func (s *APIDataService) GetRoundCompetitionFixtures(competitionId int64, round int) ([]models.APIFixture, error) {
 	roundTitle := fmt.Sprintf("Round %d", round)

--- a/backend/internal/services/api_data_service.go
+++ b/backend/internal/services/api_data_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aussiebroadwan/tipping/backend/config"
 	"github.com/aussiebroadwan/tipping/backend/internal/db"
 	"github.com/aussiebroadwan/tipping/backend/internal/models"
 )
@@ -152,9 +153,14 @@ func (s *APIDataService) GetCompetitionFixtures(competitionId int64) ([]models.A
 
 // GetCompetitionFixtures fetches fixtures for a specific competition and converts them to API models.
 func (s *APIDataService) GetRoundCompetitionFixtures(competitionId int64, round int) ([]models.APIFixture, error) {
+	roundTitle := fmt.Sprintf("Round %d", round)
+	if competitionId == config.CompetitionStateOfOrigin || competitionId == config.CompetitionStateOfOriginWomens {
+		roundTitle = fmt.Sprintf("Game %d", round)
+	}
+
 	fixtures, err := s.queries.ListRoundMatchDetailsByCompetitionID(s.ctx, db.ListRoundMatchDetailsByCompetitionIDParams{
 		CompetitionID: competitionId,
-		Roundtitle:    fmt.Sprintf("Round %d", round),
+		Roundtitle:    roundTitle,
 	})
 	if err != nil {
 		return nil, err

--- a/backend/internal/services/api_data_service.go
+++ b/backend/internal/services/api_data_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aussiebroadwan/tipping/backend/internal/db"
 	"github.com/aussiebroadwan/tipping/backend/internal/models"
@@ -77,9 +78,84 @@ func (s *APIDataService) GetFixtures() ([]models.APIFixture, error) {
 	return apiFixtures, nil
 }
 
+// GetFixtures fetches all fixtures with match details from the database with a given round and converts them to API models.
+func (s *APIDataService) GetRoundFixtures(round int) ([]models.APIFixture, error) {
+	fixtures, err := s.queries.ListRoundMatchDetails(s.ctx, fmt.Sprintf("Round %d", round))
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert database models to API models.
+	apiFixtures := make([]models.APIFixture, 0)
+	for _, f := range fixtures {
+		apiFixtures = append(apiFixtures, models.APIFixture{
+			ID:            f.Fixture.ID,
+			CompetitionID: f.Fixture.CompetitionID,
+			RoundTitle:    f.Fixture.Roundtitle,
+			MatchState:    f.Fixture.Matchstate,
+			Venue:         f.Fixture.Venue,
+			VenueCity:     f.Fixture.Venuecity,
+			HomeTeam: models.APITeam{
+				Nickname: f.Team.Nickname,
+				Score:    f.MatchDetail.HometeamScore,
+				Odds:     f.MatchDetail.HometeamOdds,
+				Form:     f.MatchDetail.HometeamForm,
+			},
+			AwayTeam: models.APITeam{
+				Nickname: f.Team_2.Nickname,
+				Score:    f.MatchDetail.AwayteamScore,
+				Odds:     f.MatchDetail.AwayteamOdds,
+				Form:     f.MatchDetail.AwayteamForm,
+			},
+			KickOffTime: f.Fixture.Kickofftime.Time,
+		})
+	}
+
+	return apiFixtures, nil
+}
+
 // GetCompetitionFixtures fetches fixtures for a specific competition and converts them to API models.
 func (s *APIDataService) GetCompetitionFixtures(competitionId int64) ([]models.APIFixture, error) {
 	fixtures, err := s.queries.ListMatchDetailsByCompetitionID(s.ctx, competitionId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert database models to API models.
+	apiFixtures := make([]models.APIFixture, 0)
+	for _, f := range fixtures {
+		apiFixtures = append(apiFixtures, models.APIFixture{
+			ID:            f.Fixture.ID,
+			CompetitionID: f.Fixture.CompetitionID,
+			RoundTitle:    f.Fixture.Roundtitle,
+			MatchState:    f.Fixture.Matchstate,
+			Venue:         f.Fixture.Venue,
+			VenueCity:     f.Fixture.Venuecity,
+			HomeTeam: models.APITeam{
+				Nickname: f.Team.Nickname,
+				Score:    f.MatchDetail.HometeamScore,
+				Odds:     f.MatchDetail.HometeamOdds,
+				Form:     f.MatchDetail.HometeamForm,
+			},
+			AwayTeam: models.APITeam{
+				Nickname: f.Team_2.Nickname,
+				Score:    f.MatchDetail.AwayteamScore,
+				Odds:     f.MatchDetail.AwayteamOdds,
+				Form:     f.MatchDetail.AwayteamForm,
+			},
+			KickOffTime: f.Fixture.Kickofftime.Time,
+		})
+	}
+
+	return apiFixtures, nil
+}
+
+// GetCompetitionFixtures fetches fixtures for a specific competition and converts them to API models.
+func (s *APIDataService) GetRoundCompetitionFixtures(competitionId int64, round int) ([]models.APIFixture, error) {
+	fixtures, err := s.queries.ListRoundMatchDetailsByCompetitionID(s.ctx, db.ListRoundMatchDetailsByCompetitionIDParams{
+		CompetitionID: competitionId,
+		Roundtitle:    fmt.Sprintf("Round %d", round),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/services/api_data_service.go
+++ b/backend/internal/services/api_data_service.go
@@ -79,42 +79,6 @@ func (s *APIDataService) GetFixtures() ([]models.APIFixture, error) {
 	return apiFixtures, nil
 }
 
-// GetFixtures fetches all fixtures with match details from the database with a given round and converts them to API models.
-func (s *APIDataService) GetRoundFixtures(round int) ([]models.APIFixture, error) {
-	fixtures, err := s.queries.ListRoundMatchDetails(s.ctx, fmt.Sprintf("Round %d", round))
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert database models to API models.
-	apiFixtures := make([]models.APIFixture, 0)
-	for _, f := range fixtures {
-		apiFixtures = append(apiFixtures, models.APIFixture{
-			ID:            f.Fixture.ID,
-			CompetitionID: f.Fixture.CompetitionID,
-			RoundTitle:    f.Fixture.Roundtitle,
-			MatchState:    f.Fixture.Matchstate,
-			Venue:         f.Fixture.Venue,
-			VenueCity:     f.Fixture.Venuecity,
-			HomeTeam: models.APITeam{
-				Nickname: f.Team.Nickname,
-				Score:    f.MatchDetail.HometeamScore,
-				Odds:     f.MatchDetail.HometeamOdds,
-				Form:     f.MatchDetail.HometeamForm,
-			},
-			AwayTeam: models.APITeam{
-				Nickname: f.Team_2.Nickname,
-				Score:    f.MatchDetail.AwayteamScore,
-				Odds:     f.MatchDetail.AwayteamOdds,
-				Form:     f.MatchDetail.AwayteamForm,
-			},
-			KickOffTime: f.Fixture.Kickofftime.Time,
-		})
-	}
-
-	return apiFixtures, nil
-}
-
 // GetCompetitionFixtures fetches fixtures for a specific competition and converts them to API models.
 func (s *APIDataService) GetCompetitionFixtures(competitionId int64) ([]models.APIFixture, error) {
 	fixtures, err := s.queries.ListMatchDetailsByCompetitionID(s.ctx, competitionId)

--- a/backend/internal/services/nrl_data_service.go
+++ b/backend/internal/services/nrl_data_service.go
@@ -50,6 +50,18 @@ func (s *NRLDataService) StoreFixtureAndDetails(fixture models.NRLFixture) error
 		return err
 	}
 
+	// Update Competition with current round
+	if fixture.IsCurrentRound {
+		// Update Competition with current round
+		_, err = s.queries.UpdateCompetitionRound(s.ctx, db.UpdateCompetitionRoundParams{
+			ID:    int64(compID),
+			Round: &fixture.RoundTitle,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update competition round: %w", err)
+		}
+	}
+
 	// Store each team
 	if err := s.storeTeam(fixture.HomeTeam, compID); err != nil {
 		return fmt.Errorf("failed to store home team: %w", err)

--- a/backend/internal/services/nrl_scheduled_service.go
+++ b/backend/internal/services/nrl_scheduled_service.go
@@ -65,6 +65,7 @@ func (s *NRLScheduledService) FetchAndStoreData(ctx context.Context) {
 			log.Printf("Error fetching fixtures for competition %d: %v", competitionID, err)
 			continue
 		}
+		time.Sleep(1 * time.Second)
 
 		// Store each fetched fixture and its details.
 		for _, fixture := range fixtures {
@@ -81,6 +82,7 @@ func (s *NRLScheduledService) FetchAndStoreData(ctx context.Context) {
 		}
 
 		log.Printf("Fetched and stored %d fixtures for competition %d", len(fixtures), competitionID)
+		time.Sleep(5 * time.Second)
 	}
 
 	log.Println("Completed scheduled fetch of NRL data")

--- a/backend/internal/services/nrl_service.go
+++ b/backend/internal/services/nrl_service.go
@@ -86,7 +86,7 @@ func (s *NRLService) FetchFixtures(competitionID int64, roundNum, season int) ([
 // fetchMatchDetail fetches additional match details for a specific fixture using its matchCentreURL.
 func (s *NRLService) fetchMatchDetail(matchCentreURL string) (*models.NRLFixture, error) {
 	// Full URL for the match details data
-	url := fmt.Sprintf("%s%s/data", s.baseURL, matchCentreURL)
+	url := fmt.Sprintf("%s%sdata", s.baseURL, matchCentreURL)
 	resp, err := s.client.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch match details from %s: %w", matchCentreURL, err)

--- a/backend/tests/api/api_test.go
+++ b/backend/tests/api/api_test.go
@@ -55,6 +55,21 @@ func TestGetCompetitionFixturesAPI(t *testing.T) {
 	assert.Equal(t, 2, len(fixtures))
 }
 
+func TestGetCompetitionRoundFixturesAPI(t *testing.T) {
+	req, err := http.NewRequest("GET", "/api/v1/fixtures/111?round=26", nil)
+	assert.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handlerRouter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var fixtures []models.APIFixture
+	err = json.Unmarshal(rr.Body.Bytes(), &fixtures)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(fixtures))
+}
+
 func TestGetMatchDetailsAPI(t *testing.T) {
 	req, err := http.NewRequest("GET", "/api/v1/fixtures/111/20241112610", nil)
 	assert.NoError(t, err)

--- a/backend/tests/api/api_test.go
+++ b/backend/tests/api/api_test.go
@@ -40,8 +40,23 @@ func TestGetFixturesAPI(t *testing.T) {
 	assert.Equal(t, 3, len(fixtures))
 }
 
-func TestGetCompetitionFixturesAPI(t *testing.T) {
+func TestGetCompetitionNoRoundFixturesAPI(t *testing.T) {
 	req, err := http.NewRequest("GET", "/api/v1/fixtures/111", nil)
+	assert.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handlerRouter.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var fixtures []models.APIFixture
+	err = json.Unmarshal(rr.Body.Bytes(), &fixtures)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(fixtures))
+}
+
+func TestGetCompetitionFixturesAPI(t *testing.T) {
+	req, err := http.NewRequest("GET", "/api/v1/fixtures/111?round=all", nil)
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()

--- a/backend/tests/api/db_seed_test.go
+++ b/backend/tests/api/db_seed_test.go
@@ -107,7 +107,7 @@ func addBulldogsVsSeaEaglesUpcomingFixture() error {
 
 	fixture := models.NRLFixture{
 		ID:             "20241112620",
-		RoundTitle:     "Round 26",
+		RoundTitle:     "Round 27",
 		MatchState:     "Upcoming",
 		KickOffTime:    "2024-08-30T08:00:00Z",
 		Venue:          "Accor Stadium",


### PR DESCRIPTION
Closes #15 


This PR tracks the current round of each competitions to make it easier to filter rounds. This also adds a `round` query parameter which can filter the fixtures defaulting to display the current round when not provided otherwise support `all` or a number for the `round` query parameter. I also figured it wouldn't make much sense to support the round filtering for the `/fixtures` endpoint as the round works differently depending on if its is a NRL game or State of Origin.